### PR TITLE
Use Assembly Info To Build GitHub Product Header

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Display the help screen.
 Display version information.
 
 ### ChangelogGenerator-new
-Create a new or override a existing changelog file.
+Generate a new or override a existing changelog file.
 
 ```
 --repository     Required. Set the repository name.
 
 --owner          Required. Set the owner of the repository.
 
---token          GitHub authenfication token.
+--token          GitHub authentication token.
 
 -o, --output     (Default: CHANGELOG.md) Set output file name.
 

--- a/src/ChangelogGenerator/ChangelogGenerator.csproj
+++ b/src/ChangelogGenerator/ChangelogGenerator.csproj
@@ -6,6 +6,7 @@
         <FileVersion>0.1.0</FileVersion>
         <AssemblyVersion>0.1.0</AssemblyVersion>
         <Version>0.1.0</Version>
+        <Company>Darius Weber</Company>
     </PropertyGroup>
     
     <PropertyGroup>

--- a/src/ChangelogGenerator/Verbs/New/NewOptions.cs
+++ b/src/ChangelogGenerator/Verbs/New/NewOptions.cs
@@ -3,7 +3,7 @@
 
 namespace ChangelogGenerator.Verbs.New
 {
-    [Verb("new", HelpText = "Generate a new changelog file for a repository.")]
+    [Verb("new", HelpText = "Generate a new or override a existing changelog file.")]
     internal class NewOptions : Options
     {
     }

--- a/src/ChangelogGenerator/Verbs/Options.cs
+++ b/src/ChangelogGenerator/Verbs/Options.cs
@@ -20,13 +20,13 @@ namespace ChangelogGenerator.Verbs
         [Option("token",
                 Required = false,
                 Default  = null,
-                HelpText = "GitHub authenfication token.")]
+                HelpText = "GitHub authentication token.")]
         public string Token { get; set; } = null;
 
         [Option('o', "output",
                 Required = false,
                 Default  = "CHANGELOG.md",
-                HelpText = "Set output file name. Default: CHANGELOG.md.")]
+                HelpText = "Set output file name.")]
         public string Output { get; set; } = "CHANGELOG.md";
 
         [Option('v', "verbose",


### PR DESCRIPTION
## Proposed changes

Use assembly info to generate the github product header.
Additionaly fix some help texts


## Checklist

- [X] Code compiles correctly
- [X] Created tests which fail without the change (if possible)
- [X] All tests passing
- [X] Extend the README / documentation, if necessary
- [X] Applied the code style
