### PR TITLE
Reorder options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Display version information.
 Generate a new or override a existing changelog file.
 
 ```
---repository     Required. Set the repository name.
-
 --owner          Required. Set the owner of the repository.
+
+--repository     Required. Set the repository name.
 
 --token          GitHub authentication token.
 

--- a/src/ChangelogGenerator/Verbs/Options.cs
+++ b/src/ChangelogGenerator/Verbs/Options.cs
@@ -5,17 +5,17 @@ namespace ChangelogGenerator.Verbs
 {
     internal class Options
     {
-        [Option("repository",
-                Required = true,
-                Default  = null,
-                HelpText = "Set the repository name.")]
-        public string Repository { get; set; }
-
         [Option("owner",
                 Required = true,
                 Default  = null,
                 HelpText = "Set the owner of the repository.")]
         public string Owner { get; set; }
+
+        [Option("repository",
+                Required = true,
+                Default  = null,
+                HelpText = "Set the repository name.")]
+        public string Repository { get; set; }
 
         [Option("token",
                 Required = false,


### PR DESCRIPTION
## Proposed changes

Reorder order of options. List owner before repository.


## Checklist

- [X] Code compiles correctly
- [X] All tests passing
- [X] Extend the README / documentation, if necessary
- [X] Applied the code style


## Where has this been tested?

**Operating System**: Windows 10


## Changelog

- fixed: order of options
